### PR TITLE
[ORBIDDER] set bid currency to EUR, because we only bit with EUR

### DIFF
--- a/adapters/orbidder/orbidder.go
+++ b/adapters/orbidder/orbidder.go
@@ -119,6 +119,9 @@ func (rcv OrbidderAdapter) MakeBids(internalRequest *openrtb.BidRequest, externa
 			})
 		}
 	}
+
+	// set currency to EUR, because we only will bid on EUR
+	bidResponse.Currency = "EUR"
 	return bidResponse, nil
 }
 

--- a/openrtb_ext/bidders.go
+++ b/openrtb_ext/bidders.go
@@ -102,6 +102,7 @@ const (
 	BidderNinthDecimal     BidderName = "ninthdecimal"
 	BidderNoBid            BidderName = "nobid"
 	BidderOpenx            BidderName = "openx"
+	BidderOrbidder         BidderName = "orbidder"
 	BidderPubmatic         BidderName = "pubmatic"
 	BidderPubnative        BidderName = "pubnative"
 	BidderPulsepoint       BidderName = "pulsepoint"


### PR DESCRIPTION
Wir erstellen mit NewBidderResponseWithBidsCapacity den Response in unserem Adapter und liefern dann "USD",
aber wir möchten nur in EUR bieten, daher denke ich ist es sinnvoll wenn wir Currency = "EUR" setzten.