### PR TITLE
add gvlVendorID to bidder-info/orbidder.yaml

### DIFF
--- a/adapters/orbidder/orbidder.go
+++ b/adapters/orbidder/orbidder.go
@@ -118,8 +118,9 @@ func (rcv OrbidderAdapter) MakeBids(internalRequest *openrtb2.BidRequest, extern
 			})
 		}
 	}
-	// orbidder only supports EUR
-	bidResponse.Currency = "EUR"
+	if bidResp.Cur != "" {
+		bidResponse.Currency = bidResp.Cur
+	}
 	return bidResponse, nil
 }
 

--- a/adapters/orbidder/orbidder.go
+++ b/adapters/orbidder/orbidder.go
@@ -110,7 +110,6 @@ func (rcv OrbidderAdapter) MakeBids(internalRequest *openrtb2.BidRequest, extern
 	}
 
 	bidResponse := adapters.NewBidderResponseWithBidsCapacity(5)
-
 	for _, seatBid := range bidResp.SeatBid {
 		for _, bid := range seatBid.Bid {
 			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
@@ -119,6 +118,8 @@ func (rcv OrbidderAdapter) MakeBids(internalRequest *openrtb2.BidRequest, extern
 			})
 		}
 	}
+	// orbidder only supports EUR
+	bidResponse.Currency = "EUR"
 	return bidResponse, nil
 }
 

--- a/static/bidder-info/orbidder.yaml
+++ b/static/bidder-info/orbidder.yaml
@@ -5,6 +5,3 @@ capabilities:
   app:
     mediaTypes:
       - banner
-  site:
-    mediaTypes:
-      - banner

--- a/static/bidder-info/orbidder.yaml
+++ b/static/bidder-info/orbidder.yaml
@@ -1,5 +1,6 @@
 maintainer:
   email: "realtime-siggi@otto.de"
+gvlVendorID: 559
 capabilities:
   app:
     mediaTypes:


### PR DESCRIPTION
Bei dem Vorbereiten der APP Verstellung morgen, ist mir aufgefallen das wir auch mit unserem Setup keine IFA mehr in der SSP haben.

Was ist passiert:
Das aktulle Prebid-Mobile-SDK schickt folgendes Flag mit wenn gdpr aktiv ist: "regs":{"ext":{"gdpr":1}}.
Dieses bewirkt im Prebid-Server das geschaut wird ob es für den Bidder eine Vendor ID gibt und ob es in der "VendorList" einen Eintrag zu dieser ID gibt. 
Dann wird mittels den Vendor-Daten und der Funktion "gdpr.allowPI" festgelegt, ob Otto die Device.IFA und andere UserIds erhalten darf.

Da für unseren Adapter keine gvlVendorID hinterlegt war, wurden die User Informationen gelöscht und sind nicht bei uns angekommen.